### PR TITLE
fix: visualize_results.pyでモデル名を動的に指定可能に

### DIFF
--- a/README.md
+++ b/README.md
@@ -884,6 +884,9 @@ python visualize_results.py
 # カスタムCSVファイルを指定
 python visualize_results.py my_evaluation_results.csv
 
+# モデル名を指定して可視化（PNGファイルに実際のモデル名が表示されます）
+python visualize_results.py evaluation_output.csv --model-a claude4.5-sonnet --model-b claude4.5-haiku
+
 # ragas_evaluation_output.csvを可視化
 python visualize_results.py ragas_evaluation_output.csv
 ```
@@ -913,7 +916,10 @@ python visualize_results.py ragas_evaluation_output.csv
 # 1. 評価を実行
 python llm_judge_evaluator.py responses.csv -o evaluation_output.csv
 
-# 2. 結果を可視化
+# 2. 結果を可視化（モデル名を指定するとPNGファイルに実際のモデル名が表示されます）
+python visualize_results.py evaluation_output.csv --model-a claude4.5-sonnet --model-b claude4.5-haiku
+
+# または、モデル名を指定しない場合（デフォルトで「Model A」と「Model B」と表示）
 python visualize_results.py evaluation_output.csv
 
 # 3. 生成されたファイルを確認
@@ -923,6 +929,7 @@ ls -la evaluation_*.png evaluation_summary.txt
 **注意：**
 - エラーが発生した行（`Evaluation_Error`列に値がある行）は自動的に除外されます
 - 日本語フォントが正しく表示されない場合は、システムの日本語フォント設定を確認してください
+- `--model-a`と`--model-b`オプションでモデル名を指定すると、PNGファイルのタイトル、凡例、サマリーテーブルに実際のモデル名が表示されます。指定しない場合は「Model A」と「Model B」と表示されます
 
 -----
 

--- a/visualize_results.py
+++ b/visualize_results.py
@@ -484,6 +484,9 @@ def main():
     # カスタムCSVファイルを指定
     python visualize_results.py my_evaluation_results.csv
     
+    # モデル名を指定して可視化
+    python visualize_results.py evaluation_output.csv --model-a claude4.5-sonnet --model-b claude4.5-haiku
+    
     # ragas_evaluation_output.csvを可視化
     python visualize_results.py ragas_evaluation_output.csv
 
@@ -513,6 +516,20 @@ def main():
         help="評価結果のCSVファイル（デフォルト: evaluation_output.csv）",
     )
 
+    parser.add_argument(
+        "--model-a",
+        type=str,
+        default=None,
+        help="Model Aの名前（例: claude4.5-sonnet）。指定しない場合は「Model A」と表示されます。",
+    )
+
+    parser.add_argument(
+        "--model-b",
+        type=str,
+        default=None,
+        help="Model Bの名前（例: claude4.5-haiku）。指定しない場合は「Model B」と表示されます。",
+    )
+
     args = parser.parse_args()
     csv_file = args.input_csv
 
@@ -534,10 +551,30 @@ def main():
 
     # グラフを作成
     log_info("グラフを作成中...")
-    create_score_comparison_chart(df_clean, output_files["evaluation_comparison"])
-    create_score_distribution_chart(df_clean, output_files["evaluation_distribution"])
-    create_boxplot_chart(df_clean, output_files["evaluation_boxplot"])
-    create_summary_table(df_clean, output_files["evaluation_summary"])
+    create_score_comparison_chart(
+        df_clean,
+        output_files["evaluation_comparison"],
+        model_a_name=args.model_a,
+        model_b_name=args.model_b,
+    )
+    create_score_distribution_chart(
+        df_clean,
+        output_files["evaluation_distribution"],
+        model_a_name=args.model_a,
+        model_b_name=args.model_b,
+    )
+    create_boxplot_chart(
+        df_clean,
+        output_files["evaluation_boxplot"],
+        model_a_name=args.model_a,
+        model_b_name=args.model_b,
+    )
+    create_summary_table(
+        df_clean,
+        output_files["evaluation_summary"],
+        model_a_name=args.model_a,
+        model_b_name=args.model_b,
+    )
 
     log_info("")
     log_section("✓ 可視化完了!")


### PR DESCRIPTION
## 概要

`visualize_results.py`で生成されるPNGファイルのモデル名が固定（`claude3.5-sonnet`と`claude4.5-haiku`）になっていた問題を修正しました。

## 問題

- PNGファイルのタイトル、凡例、サマリーテーブルに表示されるモデル名が固定されていた
- `claude4.5-sonnet`など他のモデル名を使用する場合、表示が不正確になっていた

## 修正内容

### 1. 可視化関数の拡張

以下の関数に`model_a_name`と`model_b_name`パラメータを追加：
- `create_score_comparison_chart()`
- `create_score_distribution_chart()`
- `create_boxplot_chart()`
- `create_summary_table()`

### 2. コマンドライン引数の追加

- `--model-a`: Model Aの名前を指定（例: `claude4.5-sonnet`）
- `--model-b`: Model Bの名前を指定（例: `claude4.5-haiku`）

### 3. 動的なラベル表示

- モデル名が指定された場合はその名前を使用
- 指定されない場合は`Model A`と`Model B`を使用（後方互換性を維持）

### 4. ドキュメント更新

- すべての関数のdocstringを更新して新しいパラメータを記載
- `typing.Optional`をインポート

## 使用方法

```bash
# モデル名を指定して可視化
python visualize_results.py evaluation_output.csv --model-a claude4.5-sonnet --model-b claude4.5-haiku

# モデル名を指定しない場合（デフォルトで「Model A」と「Model B」と表示）
python visualize_results.py evaluation_output.csv
```

## 影響範囲

- PNGファイルのタイトル、凡例、サマリーテーブルに実際のモデル名が表示される
- 後方互換性を維持（モデル名を指定しない場合は従来通り`Model A`と`Model B`と表示）

## テスト

- すべてのユニットテストが通過（212 passed）
- docstringのテストも通過