### PR TITLE
feat: run_full_pipeline.pyに--judge-modelオプションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -968,6 +968,9 @@ python run_full_pipeline.py questions.txt --model-a claude4.5-sonnet --model-b c
 
 # 評価行数を制限
 python run_full_pipeline.py questions.txt --limit 5
+
+# 評価用のモデルを指定（評価スクリプトの--modelオプションに渡される）
+python run_full_pipeline.py questions.txt --judge-model gpt-5
 ```
 
 **コマンドライン引数：**
@@ -981,6 +984,7 @@ python run_full_pipeline.py questions.txt --limit 5
 - `--model-a`, `--model-b`: モデル名（`collect_responses.py`に渡される）
 - `--api-url`: API URL（`collect_responses.py`に渡される）
 - `--limit`: 評価行数の制限（評価スクリプトに渡される）
+- `--judge-model`: 評価用のモデル名（評価スクリプトの`--model`オプションに渡される）
 - `--skip-collect`: 収集ステップをスキップ（既存の`collected_responses.csv`を使用）
 - `--skip-visualize`: 可視化ステップをスキップ
 - `--collect-output`: 収集ステップの出力ファイル名（デフォルト: `collected_responses.csv`）
@@ -1014,8 +1018,11 @@ python run_full_pipeline.py questions.txt --evaluator all
 # 4. 既存のCSVファイルを使用して評価と可視化のみ実行
 python run_full_pipeline.py questions.txt --skip-collect
 
-# 5. Makefileを使用
-make pipeline ARGS="questions.txt --evaluator llm-judge"
+# 5. 評価用モデルを指定して実行
+python run_full_pipeline.py questions.txt --judge-model gpt-5
+
+# 6. Makefileを使用
+make pipeline ARGS="questions.txt --evaluator llm-judge --judge-model gpt-5"
 ```
 
 **注意：**

--- a/run_full_pipeline.py
+++ b/run_full_pipeline.py
@@ -295,6 +295,9 @@ Examples:
 
     # Custom models and API URL
     python run_full_pipeline.py questions.txt --model-a claude4.5-sonnet --model-b claude4.5-haiku --api-url http://localhost:8080/api/v2/questions
+
+    # Custom judge model for evaluation
+    python run_full_pipeline.py questions.txt --judge-model gpt-5
         """,
     )
 
@@ -336,6 +339,13 @@ Examples:
         type=int,
         default=None,
         help="Limit number of rows to process (passed to evaluation script)",
+    )
+
+    parser.add_argument(
+        "--judge-model",
+        type=str,
+        default=None,
+        help="Model name for evaluation (passed to evaluation script as --model)",
     )
 
     parser.add_argument(
@@ -402,6 +412,7 @@ Examples:
         args.evaluator,
         args.collect_output,
         limit=args.limit,
+        model_name=args.judge_model,
     )
     if not success:
         log_error("Pipeline failed at evaluation step")


### PR DESCRIPTION
## 概要
`run_full_pipeline.py`で評価スクリプトのモデル（`--model`オプション）を指定できるように`--judge-model`オプションを追加しました。

## 変更内容
1. `run_full_pipeline.py`に`--judge-model`オプションを追加
2. `main()`から`run_evaluation_step()`に`model_name`を渡すように修正（L401付近）
3. `tests/test_run_full_pipeline.py`に`--judge-model`オプションのテストを追加
4. `README.md`に`--judge-model`オプションの説明と使用例を追加

## テスト
- `make test`で273個のテストがすべて通過
- `--judge-model`オプションが評価スクリプトに正しく渡されることを確認
- llm-judge、ragas、format-clarity、allの各評価タイプで動作確認

## 使用例
```bash
# 評価用モデルを指定
python run_full_pipeline.py questions.txt --judge-model gpt-5

# Makefileを使用
make pipeline ARGS="questions.txt --evaluator llm-judge --judge-model gpt-5"
```

## 影響範囲
- `run_full_pipeline.py`: CLIオプション追加、`run_evaluation_step()`呼び出し修正
- `tests/test_run_full_pipeline.py`: 新規テスト追加
- `README.md`: ドキュメント更新

Closes #24