### PR TITLE
fix: Evaluation_Errorが空文字列の場合も正常行として扱う

### DIFF
--- a/tests/test_visualize_results.py
+++ b/tests/test_visualize_results.py
@@ -85,6 +85,29 @@ class TestPrepareData:
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 0
 
+    def test_prepare_data_with_empty_string_errors(self):
+        """Test preparing data with empty string in Evaluation_Error (normal rows from llm_judge_evaluator.py)"""
+        # llm_judge_evaluator.py outputs empty string ("") for normal rows, not NaN
+        df = pd.DataFrame({
+            "Question": ["Q1", "Q2", "Q3"],
+            "Model_A_Citation_Score": [4, 5, 3],
+            "Evaluation_Error": ["", "", "Some error"],  # Empty string means normal row
+        })
+        result = prepare_data(df)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 2  # Empty string rows should be kept, error row should be excluded
+
+    def test_prepare_data_with_mixed_empty_string_and_nan(self):
+        """Test preparing data with both empty string and NaN in Evaluation_Error"""
+        df = pd.DataFrame({
+            "Question": ["Q1", "Q2", "Q3", "Q4"],
+            "Model_A_Citation_Score": [4, 5, 3, 2],
+            "Evaluation_Error": ["", pd.NA, "Some error", None],  # Empty string and NaN are both normal
+        })
+        result = prepare_data(df)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 3  # Empty string, NaN, and None rows should be kept, error row excluded
+
     def test_prepare_data_empty_dataframe(self):
         """Test preparing empty dataframe"""
         df = pd.DataFrame()

--- a/visualize_results.py
+++ b/visualize_results.py
@@ -92,8 +92,14 @@ def prepare_data(df: pd.DataFrame) -> pd.DataFrame:
         column exists, returns the original DataFrame unchanged.
     """
     # エラーが発生した行を除外
+    # llm_judge_evaluator.py outputs empty string ("") for normal rows, not NaN
+    # So we need to keep rows where Evaluation_Error is empty string, NaN, or None
     if "Evaluation_Error" in df.columns:
-        df_clean = df[df["Evaluation_Error"].isna()].copy()
+        # Keep rows where Evaluation_Error is NaN, None, or empty string
+        # Exclude rows where Evaluation_Error has a non-empty error message
+        df_clean = df[
+            df["Evaluation_Error"].isna() | (df["Evaluation_Error"] == "")
+        ].copy()
         error_count = len(df) - len(df_clean)
         if error_count > 0:
             log_warning(f"エラー行を除外: {error_count}行")


### PR DESCRIPTION
## 概要
Issue #28を修正しました。`visualize_results.py`の`prepare_data`関数で、`Evaluation_Error`が空文字列(`""`)の行も正常行として扱うように変更しました。

## 問題
`llm_judge_evaluator.py`は正常行の`Evaluation_Error`に空文字列(`""`)を出力しますが、`visualize_results.py`の`prepare_data`関数が`isna()`のみを使用していたため、空文字列の行がすべて「エラーあり」と誤判定され、有効行数が0になっていました。

## 変更内容
- `prepare_data`関数のフィルタ条件を修正: `isna()`だけでなく、空文字列(`""`)も正常行として扱う
- コメントを追加して、`llm_judge_evaluator.py`の出力形式との整合性を明記

## テスト
- 空文字列のケースをテストに追加（`test_prepare_data_with_empty_string_errors`）
- 空文字列とNaNが混在するケースもテストに追加（`test_prepare_data_with_mixed_empty_string_and_nan`）
- すべてのテスト（275個）がパスすることを確認

## 影響範囲
- `visualize_results.py`を用いた全ての可視化（`run_full_pipeline.py`からの利用も含む）が正常に動作するようになります

Closes #28