### PR TITLE
fix: ハードコードされた推定コスト表示を削除し、ガイダンスメッセージに置き換える

### DIFF
--- a/format_clarity_evaluator.py
+++ b/format_clarity_evaluator.py
@@ -492,7 +492,7 @@ def process_csv(
     else:
         log_warning(f"WARNING: This will make {len(df)} API calls to {model_name}")
         log_warning(
-            f"Estimated cost: ${len(df) * 0.05:.2f} - ${len(df) * 0.20:.2f} (rough estimate)"
+            "API costs will be incurred. It is recommended to test with a small number of rows first using the -n flag."
         )
 
         # Prompt for confirmation if processing many rows (unless non-interactive mode)

--- a/llm_judge_evaluator.py
+++ b/llm_judge_evaluator.py
@@ -700,7 +700,7 @@ def process_csv(
     else:
         log_warning(f"API呼び出し回数: {len(df)}回（モデル: {model_name}）", indent=0)
         log_warning(
-            f"推定コスト: ${len(df) * 0.15:.2f} - ${len(df) * 0.50:.2f}（概算）",
+            "APIコストがかかるため、まずは-nフラグで少量から試すことを推奨します",
             indent=0,
         )
 


### PR DESCRIPTION
## 概要
Issue #30を解決しました。`llm_judge_evaluator.py`と`format_clarity_evaluator.py`のハードコードされた推定コスト表示を削除し、より適切なガイダンスメッセージに置き換えました。

## 変更内容

### コスト表示の削除
- `llm_judge_evaluator.py`: `推定コスト: $${len(df) * 0.15:.2f} - $${len(df) * 0.50:.2f}（概算）`を削除
- `format_clarity_evaluator.py`: `Estimated cost: $${len(df) * 0.05:.2f} - $${len(df) * 0.20:.2f} (rough estimate)`を削除

### ガイダンスメッセージの追加
- `llm_judge_evaluator.py`: 「APIコストがかかるため、まずは-nフラグで少量から試すことを推奨します」
- `format_clarity_evaluator.py`: "API costs will be incurred. It is recommended to test with a small number of rows first using the -n flag."

### テスト
- `test_process_csv_no_cost_estimate_message`を追加して、コスト表示が削除されたことを確認
- ガイダンスメッセージが表示されることを確認

## 影響範囲
- ユーザーが誤解しやすい固定式のコスト表示を削除し、より適切なガイダンスを提供
- 実際の料金体系と乖離した情報を表示しないことで、ユーザーの誤解を防止

Closes #30