### PR TITLE
refactor: モデル固定の印象を与える表現を修正（実装とドキュメント）

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,7 +650,7 @@ python ragas_llm_judge_evaluator.py my_data.csv -n 3 -m gpt-4.1
 2.  **Model_A_Response**: モデルAの完全な応答（ReActログ形式）
 3.  **Model_B_Response**: モデルBの完全な応答（ReActログ形式）
 
-**注意**: ヘッダー行は任意です。スクリプトは自動的にヘッダー行を検出し、ヘッダー行がない場合は最初の行をデータとして扱います。カラム名は`Model_A_Response`/`Model_B_Response`または`Claude_35_Raw_Log`/`Claude_45_Raw_Log`のいずれもサポートされます（後者は互換性のためのエイリアスで、実際のモデル名とは無関係です）。評価するモデルは固定されておらず、任意の2つのモデルを比較できます。なお、出力CSVの列名（`Claude_3.5_Final_Answer`、`Claude_4.5_Final_Answer`）は実装上の都合で固定されていますが、実際のモデル名とは無関係です。
+**注意**: ヘッダー行は任意です。スクリプトは自動的にヘッダー行を検出し、ヘッダー行がない場合は最初の行をデータとして扱います。カラム名は`Model_A_Response`/`Model_B_Response`または`Claude_35_Raw_Log`/`Claude_45_Raw_Log`のいずれもサポートされます（後者は互換性のためのエイリアスで、実際のモデル名とは無関係です）。評価するモデルは固定されておらず、任意の2つのモデルを比較できます。
 
 ### 使用方法
 
@@ -724,8 +724,8 @@ python format_clarity_evaluator.py input.csv
 | 列 | 説明 |
 |--------|-------------|
 | `Question` | 元の質問 |
-| `Claude_3.5_Final_Answer` | モデルAのログから解析された最終回答（**注意**: 列名は実装上の都合で固定されていますが、実際のモデル名とは無関係です。任意のモデルAの回答が格納されます） |
-| `Claude_4.5_Final_Answer` | モデルBのログから解析された最終回答（**注意**: 列名は実装上の都合で固定されていますが、実際のモデル名とは無関係です。任意のモデルBの回答が格納されます） |
+| `Model_A_Final_Answer` | モデルAのログから解析された最終回答 |
+| `Model_B_Final_Answer` | モデルBのログから解析された最終回答 |
 | `Format_Clarity_Score` | 1～5のスコア |
 | `Format_Clarity_Justification` | スコアの詳細な説明 |
 | `Evaluation_Error` | 評価が失敗した場合のエラーメッセージ |

--- a/tests/test_format_clarity_evaluator.py
+++ b/tests/test_format_clarity_evaluator.py
@@ -152,16 +152,16 @@ class TestCreateUserPrompt:
     def test_create_user_prompt_basic(self):
         """Test creating a basic user prompt"""
         question = "テスト質問"
-        claude_35_answer = "Claude 3.5の回答"
-        claude_45_answer = "Claude 4.5の回答"
+        model_a_answer = "モデルAの回答"
+        model_b_answer = "モデルBの回答"
 
-        prompt = create_user_prompt(question, claude_35_answer, claude_45_answer)
+        prompt = create_user_prompt(question, model_a_answer, model_b_answer)
 
         assert question in prompt
-        assert claude_35_answer in prompt
-        assert claude_45_answer in prompt
-        assert "Claude 3.5" in prompt
-        assert "Claude 4.5" in prompt
+        assert model_a_answer in prompt
+        assert model_b_answer in prompt
+        assert "Model A" in prompt
+        assert "Model B" in prompt
 
     def test_create_user_prompt_empty_strings(self):
         """Test creating prompt with empty strings"""


### PR DESCRIPTION
## 概要
README.mdと実装から、評価するモデルが固定されているかのような印象を与える表現を修正しました。

## 変更内容

### ドキュメントの修正
- `format_clarity_evaluator.py`の説明を汎用的な表現に変更（「Claude 3.5とClaude 4.5 Sonnet」→「2つのモデル」）
- 入力CSVの説明から特定モデル名を削除
- 出力CSVの列名説明を実装に合わせて更新（`Model_A_Final_Answer`、`Model_B_Final_Answer`）
- `collect_responses.py`の説明を汎用的な表現に変更（例としてモデル名を記載）
- 採点ルーブリックの「3.5モデル」を「ゴールデンスタンダード（モデルB）」に変更

### 実装の修正
- **出力CSVの列名を変更**: `Claude_3.5_Final_Answer` → `Model_A_Final_Answer`、`Claude_4.5_Final_Answer` → `Model_B_Final_Answer`
- **変数名を変更**: `claude_35_answer` → `model_a_answer`、`claude_45_answer` → `model_b_answer`
- **docstring、コメント、プロンプトを汎用化**: 
  - モジュールdocstringを汎用的な表現に変更
  - システムプロンプト内の「Claude 3.5 Sonnet Answer」「Claude 4.5 Sonnet Answer」を「Model A Answer」「Model B Answer」に変更
  - 関数のdocstringを更新
  - argparseのdescriptionとepilogを更新
  - ログメッセージを更新
- **テストコードを更新**: 変数名とアサーションを実装変更に合わせて更新

## 影響範囲
- READMEのドキュメント変更
- `format_clarity_evaluator.py`の実装変更（出力列名、変数名、プロンプト）
- テストコードの更新
- 既存のCSVファイルとの互換性: 出力列名が変更されるため、既存のCSVファイルを読み込む場合は列名の更新が必要です

## テスト結果
- 全テスト通過（285件）
- 既存の機能に影響なし