### PR TITLE
fix: README.mdの古いパス参照を修正（Issue #44）

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ python scripts/llm_judge_evaluator.py my_test_data.csv
 
 **注意**: ヘッダー行は任意です。スクリプトは自動的にヘッダー行を検出します。
 
-#### 期待されるReActログの構造（フォーマット済み - `utils/log_output_simplifier.py` を使用）
+#### 期待されるReActログの構造（フォーマット済み - `src/utils/log_output_simplifier.py` を使用）
 
 スクリプトは、これらのセクションを持つログを期待します：
 
@@ -862,7 +862,7 @@ python scripts/compare_processing_time.py log_file.txt
 
 **出力ファイル名のカスタマイズ：**
 
-出力ファイル名（`processing_time_*.png`、`processing_time_summary.txt`など）は`config/app_config.py`の`output_files`設定、または環境変数（`APP_OUTPUT_FILE_PROCESSING_TIME_COMPARISON`など）で変更できます。詳細は[アプリケーション設定](#アプリケーション設定設定値の外部化)セクションを参照してください。
+出力ファイル名（`processing_time_*.png`、`processing_time_summary.txt`など）は`src/config/app_config.py`の`output_files`設定、または環境変数（`APP_OUTPUT_FILE_PROCESSING_TIME_COMPARISON`など）で変更できます。詳細は[アプリケーション設定](#アプリケーション設定設定値の外部化)セクションを参照してください。
 
 **入力ファイル形式：**
 
@@ -979,7 +979,7 @@ ls -la output/evaluation_*.png output/evaluation_summary.txt
 - **エラー行のフィルタリング**: `Evaluation_Error`列に非空のエラーメッセージがある行は自動的に除外されます。`Evaluation_Error`が空文字列（`""`）または`NaN`の行は正常行として扱われ、可視化に含まれます。
 - 日本語フォントが正しく表示されない場合は、システムの日本語フォント設定を確認してください
 - `--model-a`と`--model-b`オプションでモデル名を指定すると、PNGファイルのタイトル、凡例、サマリーテーブルに実際のモデル名が表示されます。指定しない場合は「Model A」と「Model B」と表示されます
-- **出力ファイル名のカスタマイズ**: 出力ファイル名（`evaluation_*.png`、`evaluation_summary.txt`など）は`config/app_config.py`の`output_files`設定、または環境変数（`APP_OUTPUT_FILE_EVALUATION_COMPARISON`など）で変更できます。詳細は[アプリケーション設定](#アプリケーション設定設定値の外部化)セクションを参照してください。
+- **出力ファイル名のカスタマイズ**: 出力ファイル名（`evaluation_*.png`、`evaluation_summary.txt`など）は`src/config/app_config.py`の`output_files`設定、または環境変数（`APP_OUTPUT_FILE_EVALUATION_COMPARISON`など）で変更できます。詳細は[アプリケーション設定](#アプリケーション設定設定値の外部化)セクションを参照してください。
 
 -----
 
@@ -1082,7 +1082,7 @@ make pipeline ARGS="questions.txt --evaluator llm-judge --judge-model gpt-5"
 - 各ステップでエラーが発生した場合、パイプラインは適切に停止します
 - 可視化ステップでエラーが発生した場合、警告を表示してパイプラインは続行します
 - **非対話実行**: `run_full_pipeline.py`から実行する場合、評価スクリプト（`llm_judge_evaluator.py`、`format_clarity_evaluator.py`）には自動的に`--yes`フラグが付与され、10行を超える場合でも確認プロンプトが表示されずに実行されます。これにより、CI/バッチ環境での自動実行が可能です。個別に評価スクリプトを実行する場合は、`--yes`フラグを明示的に指定することで非対話実行できます。
-- **出力ファイル名のカスタマイズ**: 評価結果や処理時間レポートの出力ファイル名（`evaluation_*.png`、`processing_time_*.png`など）は`config/app_config.py`の`output_files`設定、または環境変数（`APP_OUTPUT_FILE_EVALUATION_COMPARISON`、`APP_OUTPUT_FILE_PROCESSING_TIME_COMPARISON`など）で変更できます。詳細は[アプリケーション設定](#アプリケーション設定設定値の外部化)セクションを参照してください。
+- **出力ファイル名のカスタマイズ**: 評価結果や処理時間レポートの出力ファイル名（`evaluation_*.png`、`processing_time_*.png`など）は`src/config/app_config.py`の`output_files`設定、または環境変数（`APP_OUTPUT_FILE_EVALUATION_COMPARISON`、`APP_OUTPUT_FILE_PROCESSING_TIME_COMPARISON`など）で変更できます。詳細は[アプリケーション設定](#アプリケーション設定設定値の外部化)セクションを参照してください。
 
 -----
 

--- a/tests/test_readme_paths.py
+++ b/tests/test_readme_paths.py
@@ -1,0 +1,96 @@
+"""
+Tests for README.md path references.
+
+This module tests that README.md references use the correct paths
+after project structure standardization (PR #41).
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+class TestReadmePathReferences:
+    """Test that README.md uses correct path references."""
+
+    @pytest.fixture
+    def readme_path(self) -> Path:
+        """Return path to README.md."""
+        return Path(__file__).parent.parent / "README.md"
+
+    @pytest.fixture
+    def readme_content(self, readme_path: Path) -> str:
+        """Read README.md content."""
+        return readme_path.read_text(encoding="utf-8")
+
+    def test_no_old_config_paths(self, readme_content: str):
+        """Test that README.md doesn't reference old config/ paths."""
+        # Pattern to match old config/ paths (not src/config/)
+        # Look for config/app_config.py that doesn't have src/ before it
+        old_config_pattern = r"(?<!src/)config/app_config\.py"
+        matches = list(re.finditer(old_config_pattern, readme_content))
+        
+        problematic_matches = []
+        for match in matches:
+            # Check context to ensure it's not a false positive
+            start = max(0, match.start() - 30)
+            end = min(len(readme_content), match.end() + 10)
+            context = readme_content[start:end]
+            # Skip if it's in a code comment or example that's not about file paths
+            if 'src/config' not in context and '`' in context:
+                problematic_matches.append(match.group())
+        
+        assert len(problematic_matches) == 0, (
+            f"Found old config/ paths in README.md: {problematic_matches}. "
+            "All config paths should use src/config/ prefix."
+        )
+
+    def test_no_old_utils_paths(self, readme_content: str):
+        """Test that README.md doesn't reference old utils/ paths."""
+        # Pattern to match old utils/ paths (not src/utils/)
+        # Look for utils/log_output_simplifier.py that doesn't have src/ before it
+        old_utils_pattern = r"(?<!src/)utils/log_output_simplifier\.py"
+        matches = list(re.finditer(old_utils_pattern, readme_content))
+        
+        problematic_matches = []
+        for match in matches:
+            # Check context to ensure it's not a false positive
+            start = max(0, match.start() - 30)
+            end = min(len(readme_content), match.end() + 10)
+            context = readme_content[start:end]
+            # Skip if it's in a code comment or example that's not about file paths
+            if 'src/utils' not in context and '`' in context:
+                problematic_matches.append(match.group())
+        
+        assert len(problematic_matches) == 0, (
+            f"Found old utils/ paths in README.md: {problematic_matches}. "
+            "All utils paths should use src/utils/ prefix."
+        )
+
+    def test_config_paths_use_src_prefix(self, readme_content: str):
+        """Test that config paths in README.md use src/config/ prefix."""
+        # Find all config/app_config.py references
+        config_refs = re.findall(r"`([^`]*config[^`]*\.py)`", readme_content)
+        
+        # All config file references should use src/config/ prefix
+        old_paths = [ref for ref in config_refs if ref.startswith("config/") and not ref.startswith("src/config/")]
+        
+        assert len(old_paths) == 0, (
+            f"Found config paths without src/ prefix: {old_paths}. "
+            "All config paths should use src/config/ prefix."
+        )
+
+    def test_utils_paths_use_src_prefix(self, readme_content: str):
+        """Test that utils paths in README.md use src/utils/ prefix."""
+        # Find all utils/*.py references
+        utils_refs = re.findall(r"`([^`]*utils[^`]*\.py)`", readme_content)
+        
+        # All utils file references should use src/utils/ prefix
+        old_paths = [ref for ref in utils_refs if ref.startswith("utils/") and not ref.startswith("src/utils/")]
+        
+        assert len(old_paths) == 0, (
+            f"Found utils paths without src/ prefix: {old_paths}. "
+            "All utils paths should use src/utils/ prefix."
+        )
+


### PR DESCRIPTION
## 概要

Issue #44に対応し、README.mdの古いパス参照を新しい構造に統一しました。

## 変更内容

- `config/app_config.py` → `src/config/app_config.py`（3箇所）
- `utils/log_output_simplifier.py` → `src/utils/log_output_simplifier.py`（1箇所）

## テスト

テストファーストで実装：
- `tests/test_readme_paths.py`を新規追加
- README.mdのパス参照を検証するテストを追加
- すべてのテストが通過することを確認

## 関連Issue

Closes #44