### PR TITLE
fix: Makefileのhelpメッセージでscripts/プレフィックスを使用（Issue #46）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,12 @@ help:
 	@echo "  make clean         - Clean generated files"
 	@echo ""
 	@echo "Script usage help:"
-	@echo "  make help-llm-judge      - Show usage for llm_judge_evaluator.py"
-	@echo "  make help-format-clarity - Show usage for format_clarity_evaluator.py"
-	@echo "  make help-ragas          - Show usage for ragas_llm_judge_evaluator.py"
-	@echo "  make help-collect        - Show usage for collect_responses.py"
-	@echo "  make help-visualize      - Show usage for visualize_results.py"
-	@echo "  make help-pipeline       - Show usage for run_full_pipeline.py"
+	@echo "  make help-llm-judge      - Show usage for scripts/llm_judge_evaluator.py"
+	@echo "  make help-format-clarity - Show usage for scripts/format_clarity_evaluator.py"
+	@echo "  make help-ragas          - Show usage for scripts/ragas_llm_judge_evaluator.py"
+	@echo "  make help-collect        - Show usage for scripts/collect_responses.py"
+	@echo "  make help-visualize      - Show usage for scripts/visualize_results.py"
+	@echo "  make help-pipeline       - Show usage for scripts/run_full_pipeline.py"
 	@echo ""
 	@echo "Pipeline target:"
 	@echo "  make pipeline            - Run full pipeline (collect, evaluate, visualize)"
@@ -50,32 +50,32 @@ help:
 
 help-llm-judge:
 	@echo "=========================================="
-	@echo "llm_judge_evaluator.py の使い方"
+	@echo "scripts/llm_judge_evaluator.py の使い方"
 	@echo "=========================================="
 	@$(PYTHON) scripts/llm_judge_evaluator.py --help
 
 help-format-clarity:
 	@echo "=========================================="
-	@echo "format_clarity_evaluator.py の使い方"
+	@echo "scripts/format_clarity_evaluator.py の使い方"
 	@echo "=========================================="
 	@$(PYTHON) scripts/format_clarity_evaluator.py --help
 
 help-ragas:
 	@echo "=========================================="
-	@echo "ragas_llm_judge_evaluator.py の使い方"
+	@echo "scripts/ragas_llm_judge_evaluator.py の使い方"
 	@echo "=========================================="
-	@$(PYTHON) scripts/ragas_llm_judge_evaluator.py --help 2>&1 || echo "⚠️  ragas_llm_judge_evaluator.py requires dependencies (ragas, datasets)"
+	@$(PYTHON) scripts/ragas_llm_judge_evaluator.py --help 2>&1 || echo "⚠️  scripts/ragas_llm_judge_evaluator.py requires dependencies (ragas, datasets)"
 
 help-collect:
 	@echo "=========================================="
-	@echo "collect_responses.py の使い方"
+	@echo "scripts/collect_responses.py の使い方"
 	@echo "=========================================="
 	@echo "※ 応答収集後、処理時間ログと比較チャートを自動生成します"
 	@$(PYTHON) scripts/collect_responses.py --help
 
 help-visualize:
 	@echo "=========================================="
-	@echo "visualize_results.py の使い方"
+	@echo "scripts/visualize_results.py の使い方"
 	@echo "=========================================="
 	@$(PYTHON) scripts/visualize_results.py --help
 
@@ -84,7 +84,7 @@ pipeline:
 
 help-pipeline:
 	@echo "=========================================="
-	@echo "run_full_pipeline.py の使い方"
+	@echo "scripts/run_full_pipeline.py の使い方"
 	@echo "=========================================="
 	@$(PYTHON) scripts/run_full_pipeline.py --help
 

--- a/tests/test_makefile_consistency.py
+++ b/tests/test_makefile_consistency.py
@@ -1,0 +1,87 @@
+"""
+Tests for Makefile consistency with project structure.
+
+These tests verify that Makefile uses consistent script references
+with the scripts/ prefix after PR #41.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+class TestMakefileHelpMessages:
+    """Test that Makefile help messages use scripts/ prefix."""
+
+    @pytest.fixture
+    def makefile_path(self) -> Path:
+        """Return path to Makefile."""
+        return Path(__file__).parent.parent / "Makefile"
+
+    @pytest.fixture
+    def makefile_content(self, makefile_path: Path) -> str:
+        """Read Makefile content."""
+        return makefile_path.read_text(encoding="utf-8")
+
+    def test_help_messages_use_scripts_prefix(self, makefile_content: str):
+        """Test that help messages reference scripts with scripts/ prefix."""
+        # Find help-* target definitions
+        help_targets = [
+            "help-llm-judge",
+            "help-format-clarity",
+            "help-ragas",
+        ]
+        
+        problematic_lines = []
+        lines = makefile_content.split("\n")
+        
+        for i, line in enumerate(lines, 1):
+            # Check for help target definitions
+            for target in help_targets:
+                if f"help-{target.replace('help-', '')}" in line or target in line:
+                    # Check the next few lines for script references
+                    for j in range(i, min(i + 5, len(lines))):
+                        check_line = lines[j]
+                        # Look for script names without scripts/ prefix
+                        if re.search(
+                            r"\b(llm_judge_evaluator|format_clarity_evaluator|ragas_llm_judge_evaluator)\.py\b",
+                            check_line,
+                        ):
+                            # Skip if it's in a comment or already has scripts/
+                            if "scripts/" not in check_line and not check_line.strip().startswith("#"):
+                                # Check if it's an echo statement that should show the full path
+                                if "@echo" in check_line or "echo" in check_line:
+                                    problematic_lines.append((j + 1, check_line.strip()))
+        
+        assert len(problematic_lines) == 0, (
+            f"Makefile help messages contain script references without scripts/ prefix: {problematic_lines}. "
+            "Help messages should reference scripts with scripts/ prefix for consistency."
+        )
+
+    def test_help_echo_messages_are_consistent(self, makefile_content: str):
+        """Test that echo messages in help targets are consistent."""
+        # Find all echo statements that mention script names
+        lines = makefile_content.split("\n")
+        script_names = [
+            "llm_judge_evaluator.py",
+            "format_clarity_evaluator.py",
+            "ragas_llm_judge_evaluator.py",
+        ]
+        
+        inconsistent_echoes = []
+        for i, line in enumerate(lines, 1):
+            if "@echo" in line or line.strip().startswith("echo"):
+                for script_name in script_names:
+                    if script_name in line:
+                        # Check if it's showing usage/help message
+                        if any(keyword in line.lower() for keyword in ["usage", "使い方", "help"]):
+                            # Should show scripts/ prefix for consistency
+                            if "scripts/" not in line:
+                                inconsistent_echoes.append((i + 1, line.strip()))
+        
+        assert len(inconsistent_echoes) == 0, (
+            f"Makefile help echo messages are inconsistent: {inconsistent_echoes}. "
+            "Help messages should show scripts/ prefix for consistency."
+        )
+


### PR DESCRIPTION
## 概要

Issue #46に対応し、Makefileのhelpメッセージ内のスクリプト参照を`scripts/`プレフィックス付きに統一しました。

## 変更内容

### Makefileの修正
- `help`ターゲット内のスクリプト参照を`scripts/`プレフィックス付きに更新
- すべての`help-*`ターゲット（help-llm-judge, help-format-clarity, help-ragas, help-collect, help-visualize, help-pipeline）のechoメッセージを更新
- エラーメッセージ内のスクリプト参照も統一

### テストの追加
- 新しいテストファイル `tests/test_makefile_consistency.py` を追加
- Makefileのhelpメッセージの一貫性を検証するテストを実装

## テスト結果

- 新規テスト: 2個すべて通過
- 既存テスト: 311個すべて通過
- 合計: 313個すべて通過

## 関連Issue

- Closes #46

## テストファースト

テストファーストで実装し、すべてのテストが通過することを確認しました。