### PR TITLE
test: 4つのエッジケーステストをTestProcessCsvEdgeCasesに追加

### DIFF
--- a/tests/test_llm_judge_evaluator_edge_cases.py
+++ b/tests/test_llm_judge_evaluator_edge_cases.py
@@ -5,12 +5,90 @@ This module tests edge cases and error handling paths that are not
 covered by other tests.
 """
 
+import os
 import sys
+import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
+import pandas as pd
+import pytest
 
 # Add parent directory to path to import modules
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+class TestProcessCsvEdgeCases:
+    """Tests for process_csv edge cases."""
+
+    @patch("scripts.llm_judge_evaluator.AzureOpenAI")
+    @patch("scripts.llm_judge_evaluator.OpenAI")
+    def test_process_csv_file_not_found(self, mock_openai, mock_azure):
+        """Test process_csv handles FileNotFoundError."""
+        from scripts.llm_judge_evaluator import process_csv
+
+        with pytest.raises(SystemExit):
+            process_csv("nonexistent_file.csv", "output.csv")
+
+    @patch("scripts.llm_judge_evaluator.AzureOpenAI")
+    @patch("scripts.llm_judge_evaluator.OpenAI")
+    @patch("scripts.llm_judge_evaluator.pd.read_csv")
+    def test_process_csv_empty_data_error(self, mock_read_csv, mock_openai, mock_azure):
+        """Test process_csv handles EmptyDataError."""
+        from scripts.llm_judge_evaluator import process_csv
+
+        # Mock pd.read_csv to raise EmptyDataError
+        mock_read_csv.side_effect = pd.errors.EmptyDataError("No columns to parse from file")
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+            temp_file = f.name
+
+        try:
+            with pytest.raises(SystemExit):
+                process_csv(temp_file, "output.csv")
+        finally:
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
+
+    @patch("scripts.llm_judge_evaluator.AzureOpenAI")
+    @patch("scripts.llm_judge_evaluator.OpenAI")
+    @patch("scripts.llm_judge_evaluator.pd.read_csv")
+    def test_process_csv_parser_error(self, mock_read_csv, mock_openai, mock_azure):
+        """Test process_csv handles ParserError."""
+        from scripts.llm_judge_evaluator import process_csv
+
+        # Mock pd.read_csv to raise ParserError
+        mock_read_csv.side_effect = pd.errors.ParserError("Error tokenizing data")
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+            temp_file = f.name
+
+        try:
+            with pytest.raises(SystemExit):
+                process_csv(temp_file, "output.csv")
+        finally:
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
+
+    @patch("scripts.llm_judge_evaluator.AzureOpenAI")
+    @patch("scripts.llm_judge_evaluator.OpenAI")
+    @patch("builtins.open")
+    def test_process_csv_permission_error(self, mock_open, mock_openai, mock_azure):
+        """Test process_csv handles PermissionError."""
+        from scripts.llm_judge_evaluator import process_csv
+
+        # Mock open to raise PermissionError
+        mock_open.side_effect = PermissionError("Permission denied")
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+            temp_file = f.name
+
+        try:
+            with pytest.raises(SystemExit):
+                process_csv(temp_file, "output.csv")
+        finally:
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
 
 
 class TestExtractScoresEdgeCases:


### PR DESCRIPTION
## 概要

`TestProcessCsvEdgeCases`クラスに4つのエッジケーステストを追加しました。これにより、`llm_judge_evaluator.py`の`process_csv`関数のエラー処理が包括的にテストされるようになりました。

## 変更内容

`tests/test_llm_judge_evaluator_edge_cases.py`に以下の4つのテストを追加：

- `test_process_csv_file_not_found`: FileNotFoundErrorの処理をテスト
- `test_process_csv_empty_data_error`: EmptyDataErrorの処理をテスト
- `test_process_csv_parser_error`: ParserErrorの処理をテスト
- `test_process_csv_permission_error`: PermissionErrorの処理をテスト

これらのテストは、`process_csv`関数が適切にエラーを処理し、`sys.exit(1)`を呼び出すことを確認します。

## テスト結果

すべてのテストが通過しました（317 passed）。

```
tests/test_llm_judge_evaluator_edge_cases.py::TestProcessCsvEdgeCases::test_process_csv_file_not_found PASSED
tests/test_llm_judge_evaluator_edge_cases.py::TestProcessCsvEdgeCases::test_process_csv_empty_data_error PASSED
tests/test_llm_judge_evaluator_edge_cases.py::TestProcessCsvEdgeCases::test_process_csv_parser_error PASSED
tests/test_llm_judge_evaluator_edge_cases.py::TestProcessCsvEdgeCases::test_process_csv_permission_error PASSED
```

## 関連Issue

このPRは、以前のPR #52で指摘されていた空のテストクラス`TestProcessCsvEdgeCases`の問題を解決します。コンフリクト解決時にテストが失われてしまったため、改めて実装しました。