### PR TITLE
test: time.sleepをモック化してテスト実行時間を短縮

### DIFF
--- a/tests/test_collect_responses_edge_cases.py
+++ b/tests/test_collect_responses_edge_cases.py
@@ -309,6 +309,7 @@ class TestReadQuestionsErrorHandling:
 class TestCollectResponsesConfigDefaults:
     """Tests for collect_responses config defaults."""
 
+    @patch("scripts.collect_responses.time.sleep")
     @patch("scripts.collect_responses.get_default_identity")
     @patch("scripts.collect_responses.get_timeout")
     @patch("scripts.collect_responses.get_api_delay")
@@ -321,6 +322,7 @@ class TestCollectResponsesConfigDefaults:
         mock_get_delay,
         mock_get_timeout,
         mock_get_identity,
+        mock_sleep,
     ):
         """Test collect_responses uses config defaults when None."""
         from scripts.collect_responses import collect_responses
@@ -345,4 +347,6 @@ class TestCollectResponsesConfigDefaults:
         mock_get_identity.assert_called_once()
         mock_get_timeout.assert_called_once()
         mock_get_delay.assert_called_once()
+        # Verify that time.sleep was called (for rate limiting)
+        assert mock_sleep.called
 

--- a/tests/test_llm_judge_evaluator_edge_cases.py
+++ b/tests/test_llm_judge_evaluator_edge_cases.py
@@ -116,16 +116,20 @@ class TestExtractScoresEdgeCases:
 class TestCallJudgeModelEdgeCases:
     """Tests for call_judge_model edge cases."""
 
-    def test_call_judge_model_with_none_client(self):
+    @patch("scripts.llm_judge_evaluator.time.sleep")
+    def test_call_judge_model_with_none_client(self, mock_sleep):
         """Test call_judge_model handles None client."""
         from scripts.llm_judge_evaluator import call_judge_model
 
         # call_judge_model signature: (client, question, model_a_response, model_b_response, model_name, ...)
         # When client is None, it will fail after retries and return None
+        # Mock time.sleep to avoid actual delays during retries
         result = call_judge_model(
             None, "question", "response_a", "response_b", "model", timeout=10
         )  # type: ignore[call-arg]
 
         # Should return None after all retries fail
         assert result is None
+        # Verify that time.sleep was called during retries
+        assert mock_sleep.called
 


### PR DESCRIPTION
## 概要

Issue #60と#61で指摘されていた、時間がかかるテストの問題を解決しました。

## 変更内容

### 1. `test_call_judge_model_with_none_client`
- `time.sleep`をモック化
- 実行時間: 6.01秒 → 0.13秒（約46倍高速化）

### 2. `test_collect_responses_uses_config_defaults`
- `time.sleep`をモック化
- 実行時間: 1.01秒 → 0.36秒（約2.8倍高速化）

## テスト結果

すべてのテストが通過しました（317 passed）。

## 関連Issue

Closes #60
Closes #61