### PR TITLE
デフォルトモデル名をClaude 4.5シリーズに更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,7 +903,7 @@ python scripts/collect_responses.py examples/questions.txt -o responses.csv
 python scripts/collect_responses.py examples/questions.txt --api-url http://localhost:8080/api/v1/urls
 
 # カスタムモデルを指定
-python scripts/collect_responses.py examples/questions.txt --model-a claude3.5-sonnet --model-b claude4.5-haiku
+python scripts/collect_responses.py examples/questions.txt --model-a claude4.5-sonnet --model-b claude4.5-haiku
 
 # カスタムidentity、timeout、delayを指定（デフォルト値は設定ファイルまたは環境変数から読み込まれます）
 python scripts/collect_responses.py examples/questions.txt --identity YOUR_IDENTITY --timeout 150 --delay 2.5
@@ -977,7 +977,7 @@ python scripts/compare_processing_time.py
 python scripts/compare_processing_time.py output/processing_time_log.txt
 
 # モデル名を指定して動的パターン生成を使用
-python scripts/compare_processing_time.py output/processing_time_log.txt --model-a claude3.5-sonnet --model-b claude4.5-haiku
+python scripts/compare_processing_time.py output/processing_time_log.txt --model-a claude4.5-sonnet --model-b claude4.5-haiku
 ```
 
 **コマンドラインオプション：**
@@ -1006,7 +1006,7 @@ python scripts/compare_processing_time.py output/processing_time_log.txt --model
 ログファイルには、以下のような形式で処理時間情報が含まれている必要があります：
 
 ```
-📥 [claude3.5-sonnet] ... 経過時間: 12.34秒
+📥 [claude4.5-sonnet] ... 経過時間: 12.34秒
 📥 [claude4.5-haiku] ... 経過時間: 8.90秒
 ```
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -37,6 +37,6 @@ output_files:
 # Regex patterns for processing time extraction
 # Used by compare_processing_time.py to extract processing times from log files
 regex_patterns:
-  model_a_pattern: "📥 \\[claude3\\.5-sonnet\\].*?経過時間: ([\\d.]+)秒"
+  model_a_pattern: "📥 \\[claude4\\.5-sonnet\\].*?経過時間: ([\\d.]+)秒"
   model_b_pattern: "📥 \\[claude4\\.5-haiku\\].*?経過時間: ([\\d.]+)秒"
 

--- a/scripts/collect_responses.py
+++ b/scripts/collect_responses.py
@@ -2,7 +2,7 @@
 """
 LLM Response Collector Script
 
-This script collects responses from the LLM API for two models (claude3.5-sonnet and claude4.5-haiku)
+This script collects responses from the LLM API for two models (claude4.5-sonnet and claude4.5-haiku)
 and creates a CSV file suitable for evaluation.
 
 Usage:
@@ -149,7 +149,7 @@ def call_api(
     Args:
         question: The question to ask
         api_url: The API endpoint URL
-        model_name: The model name (claude3.5-sonnet or claude4.5-haiku)
+        model_name: The model name (claude4.5-sonnet or claude4.5-haiku)
         identity: The x-amzn-oidc-identity header value (defaults to config value)
         timeout: Request timeout in seconds (defaults to config value)
         verbose: Whether to print detailed logs
@@ -298,7 +298,7 @@ def collect_responses(
     Args:
         questions: List of questions to ask
         api_url: The API endpoint URL
-        model_a: Model name for Model A (e.g., claude3.5-sonnet)
+        model_a: Model name for Model A (e.g., claude4.5-sonnet)
         model_b: Model name for Model B (e.g., claude4.5-haiku)
         identity: The x-amzn-oidc-identity header value (defaults to config value)
         timeout: Request timeout in seconds (defaults to config value)
@@ -797,7 +797,7 @@ Examples:
     python scripts/collect_responses.py examples/questions.txt --api-url http://localhost:8080/api/v1/urls -o output/responses.csv
     
     # Use custom models
-    python scripts/collect_responses.py examples/questions.txt --model-a claude3.5-sonnet --model-b claude4.5-haiku -o output/responses.csv
+    python scripts/collect_responses.py examples/questions.txt --model-a claude4.5-sonnet --model-b claude4.5-haiku -o output/responses.csv
     
     # Use custom identity
     python scripts/collect_responses.py examples/questions.txt --identity YOUR_IDENTITY -o output/responses.csv
@@ -839,8 +839,8 @@ Input file format:
 
     parser.add_argument(
         "--model-a",
-        default="claude3.5-sonnet",
-        help="Model name for Model A (default: claude3.5-sonnet)",
+        default="claude4.5-sonnet",
+        help="Model name for Model A (default: claude4.5-sonnet)",
     )
 
     parser.add_argument(

--- a/scripts/compare_processing_time.py
+++ b/scripts/compare_processing_time.py
@@ -110,7 +110,7 @@ def extract_processing_times(
     # 質問番号を生成
     question_numbers = list(range(1, len(model_a_times) + 1))
 
-    display_a = model_a_name or "claude3.5-sonnet"
+    display_a = model_a_name or "claude4.5-sonnet"
     display_b = model_b_name or "claude4.5-haiku"
     log_success(f"Model A ({display_a}) の処理時間: {len(model_a_times)}件")
     log_success(f"Model B ({display_b}) の処理時間: {len(model_b_times)}件")
@@ -154,7 +154,7 @@ def create_comparison_chart(
         [i - width / 2 for i in x],
         model_a_times,
         width,
-        label="Model A (claude3.5-sonnet)",
+        label="Model A (claude4.5-sonnet)",
         alpha=0.8,
         color="#3498db",
     )
@@ -216,7 +216,7 @@ def create_statistics_chart(
     avg_a = sum(model_a_times) / len(model_a_times)
     avg_b = sum(model_b_times) / len(model_b_times)
     bars = ax1.bar(
-        ["Model A\n(claude3.5-sonnet)", "Model B\n(claude4.5-haiku)"],
+        ["Model A\n(claude4.5-sonnet)", "Model B\n(claude4.5-haiku)"],
         [avg_a, avg_b],
         color=["#3498db", "#e74c3c"],
         alpha=0.8,
@@ -364,7 +364,7 @@ def create_summary_table(
         f.write("統計情報\n")
         f.write("=" * 70 + "\n\n")
 
-        f.write("Model A (claude3.5-sonnet):\n")
+        f.write("Model A (claude4.5-sonnet):\n")
         f.write(f"  平均: {df['Model_A_Time'].mean():.2f}秒\n")
         f.write(f"  最小: {df['Model_A_Time'].min():.2f}秒\n")
         f.write(f"  最大: {df['Model_A_Time'].max():.2f}秒\n")
@@ -423,7 +423,7 @@ def main():
     python scripts/compare_processing_time.py output/processing_time_log.txt
     
     # モデル名を指定（動的パターン生成）
-    python scripts/compare_processing_time.py output/processing_time_log.txt --model-a claude3.5-sonnet --model-b claude4.5-haiku
+    python scripts/compare_processing_time.py output/processing_time_log.txt --model-a claude4.5-sonnet --model-b claude4.5-haiku
 
 入力ファイル形式:
     処理時間ログファイルには以下の形式の行が含まれている必要があります:

--- a/scripts/run_full_pipeline.py
+++ b/scripts/run_full_pipeline.py
@@ -67,7 +67,7 @@ def run_collect_step(
     Args:
         questions_file: Path to questions file
         output_file: Output CSV file path
-        model_a: Model A name (optional, defaults to claude3.5-sonnet)
+        model_a: Model A name (optional, defaults to claude4.5-sonnet)
         model_b: Model B name (optional, defaults to claude4.5-haiku)
         api_url: API URL (optional)
         **kwargs: Additional arguments to pass to collect_responses.py
@@ -77,7 +77,7 @@ def run_collect_step(
         Returns the actual model names used (defaults if not specified)
     """
     # Default model names (matching collect_responses.py defaults)
-    DEFAULT_MODEL_A = "claude3.5-sonnet"
+    DEFAULT_MODEL_A = "claude4.5-sonnet"
     DEFAULT_MODEL_B = "claude4.5-haiku"
 
     actual_model_a = model_a or DEFAULT_MODEL_A
@@ -479,7 +479,7 @@ Examples:
             sys.exit(1)
         # If skip_collect and model names not specified, use defaults
         if not actual_model_a:
-            actual_model_a = "claude3.5-sonnet"
+            actual_model_a = "claude4.5-sonnet"
         if not actual_model_b:
             actual_model_b = "claude4.5-haiku"
 

--- a/src/config/app_config.py
+++ b/src/config/app_config.py
@@ -72,7 +72,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "processing_time_log": "output/processing_time_log.txt",
     },
     "regex_patterns": {
-        "model_a_pattern": r"📥 \[claude3\.5-sonnet\].*?経過時間: ([\d.]+)秒",
+        "model_a_pattern": r"📥 \[claude4\.5-sonnet\].*?経過時間: ([\d.]+)秒",
         "model_b_pattern": r"📥 \[claude4\.5-haiku\].*?経過時間: ([\d.]+)秒",
     },
 }

--- a/tests/test_collect_responses.py
+++ b/tests/test_collect_responses.py
@@ -233,7 +233,7 @@ class TestCallApi:
         result = call_api(
             "Test question",
             "http://example.com/api",
-            "claude3.5-sonnet",
+            "claude4.5-sonnet",
             time_log_path=str(log_file),
             question_number=2,
             model_label="Model A",
@@ -243,7 +243,7 @@ class TestCallApi:
         assert result == "Logged answer"
         assert log_file.exists()
         content = log_file.read_text(encoding="utf-8")
-        assert "claude3.5-sonnet" in content
+        assert "claude4.5-sonnet" in content
         assert "質問2" in content
         assert "Model A" in content
         assert "経過時間" in content
@@ -356,7 +356,7 @@ class TestCollectResponsesIntegration:
         df = collect_responses(
             questions=["Q1", "Q2"],
             api_url="http://example.com/api",
-            model_a="claude3.5-sonnet",
+            model_a="claude4.5-sonnet",
             model_b="claude4.5-haiku",
             time_log_path=str(log_file),
             verbose=False,
@@ -367,7 +367,7 @@ class TestCollectResponsesIntegration:
         assert mock_call_api.call_count == 4  # two models per question
         mock_generate_reports.assert_called_once_with(
             str(log_file),
-            model_a_name="claude3.5-sonnet",
+            model_a_name="claude4.5-sonnet",
             model_b_name="claude4.5-haiku",
         )
 

--- a/tests/test_collect_responses_main.py
+++ b/tests/test_collect_responses_main.py
@@ -67,7 +67,7 @@ class TestLogProcessingTimeEntry:
         log_file.write_text("# Header\n")
 
         log_processing_time_entry(
-            "claude3.5-sonnet",
+            "claude4.5-sonnet",
             1.23,
             str(log_file),
             question_number=1,
@@ -75,7 +75,7 @@ class TestLogProcessingTimeEntry:
         )
 
         content = log_file.read_text()
-        assert "📥 [claude3.5-sonnet]" in content
+        assert "📥 [claude4.5-sonnet]" in content
         assert "Model A" in content
         assert "質問1" in content
         assert "1.23秒" in content

--- a/tests/test_compare_processing_time.py
+++ b/tests/test_compare_processing_time.py
@@ -23,9 +23,9 @@ class TestExtractProcessingTimes:
 
     def test_extract_processing_times_success(self):
         """Test successful extraction of processing times"""
-        log_content = """📥 [claude3.5-sonnet] HTTPステータス: 200 (経過時間: 10.5秒)
+        log_content = """📥 [claude4.5-sonnet] HTTPステータス: 200 (経過時間: 10.5秒)
 📥 [claude4.5-haiku] HTTPステータス: 200 (経過時間: 8.3秒)
-📥 [claude3.5-sonnet] HTTPステータス: 200 (経過時間: 12.1秒)
+📥 [claude4.5-sonnet] HTTPステータス: 200 (経過時間: 12.1秒)
 📥 [claude4.5-haiku] HTTPステータス: 200 (経過時間: 9.2秒)"""
 
         with tempfile.NamedTemporaryFile(mode="w", delete=False, encoding="utf-8") as f:
@@ -50,9 +50,9 @@ class TestExtractProcessingTimes:
 
     def test_extract_processing_times_mismatched_counts(self):
         """Test handling mismatched data counts"""
-        log_content = """📥 [claude3.5-sonnet] HTTPステータス: 200 (経過時間: 10.5秒)
+        log_content = """📥 [claude4.5-sonnet] HTTPステータス: 200 (経過時間: 10.5秒)
 📥 [claude4.5-haiku] HTTPステータス: 200 (経過時間: 8.3秒)
-📥 [claude3.5-sonnet] HTTPステータス: 200 (経過時間: 12.1秒)"""
+📥 [claude4.5-sonnet] HTTPステータス: 200 (経過時間: 12.1秒)"""
 
         with tempfile.NamedTemporaryFile(mode="w", delete=False, encoding="utf-8") as f:
             f.write(log_content)


### PR DESCRIPTION
## 概要

Claude 3.5 Sonnetの廃止に伴い、デフォルトのモデル名を更新しました。

## 変更内容

- **Model A (比較対象):** `claude3.5-sonnet` → `claude4.5-sonnet`
- **Model B (ベースライン):** `claude4.5-haiku` (変更なし)

## 変更ファイル

- `scripts/collect_responses.py` - デフォルトモデル名、ドキュメント、ヘルプメッセージ
- `scripts/run_full_pipeline.py` - デフォルトモデル名、ドキュメント
- `scripts/compare_processing_time.py` - 表示名、チャートラベル
- `src/config/app_config.py` - デフォルト正規表現パターン
- `config.example.yaml` - 正規表現パターンの例
- `README.md` - コマンド例、ログ形式の例
- テストファイル (3ファイル)

## テスト

全386テストがパスしていることを確認済み。